### PR TITLE
fix NPE in DnDTabbedPane#initTargetLine(int)

### DIFF
--- a/DnDTabbedPane/src/java/example/MainPanel.java
+++ b/DnDTabbedPane/src/java/example/MainPanel.java
@@ -190,13 +190,15 @@ class DnDTabbedPane extends JTabbedPane {
             glassPane.setTargetRect(0, 0, 0, 0);
             return;
         }
-        Rectangle r = SwingUtilities.convertRectangle(this, getBoundsAt(Math.max(0, next - 1)), glassPane);
-        int a = Math.min(next, 1); // a = (next == 0) ? 0 : 1;
-        if (isTopBottomTabPlacement(getTabPlacement())) {
-            glassPane.setTargetRect(r.x + r.width * a - LINEWIDTH / 2, r.y, LINEWIDTH, r.height);
-        } else {
-            glassPane.setTargetRect(r.x, r.y + r.height * a - LINEWIDTH / 2, r.width, LINEWIDTH);
-        }
+        Optional.ofNullable(getBoundsAt(Math.max(0, next - 1))).ifPresent(boundsRect -> {
+            final Rectangle r = SwingUtilities.convertRectangle(this, boundsRect, glassPane);
+            int a = Math.min(next, 1); // a = (next == 0) ? 0 : 1;
+            if (isTopBottomTabPlacement(getTabPlacement())) {
+                glassPane.setTargetRect(r.x + r.width * a - LINEWIDTH / 2, r.y, LINEWIDTH, r.height);
+            } else {
+                glassPane.setTargetRect(r.x, r.y + r.height * a - LINEWIDTH / 2, r.width, LINEWIDTH);
+            }
+        });
     }
 
     protected void initGlassPane(Point tabPt) {


### PR DESCRIPTION
getBoundsAt(Math.max(0, next - 1)) may return null.

How to reproduce : 
* add several tabs in tabbedpane to go beyond the window size (tabs label are truncated)
* move a tab label to left or right border
* and NullPointerException

Environment : 
* Mac OS High Sierre
* java : jdk 9.0.1, language level 1.8 (java 8)