### PR TITLE
fix: #9 even after canceling the dragging of tabs with the ESC key, t…

### DIFF
--- a/DnDTabbedPane/src/java/example/MainPanel.java
+++ b/DnDTabbedPane/src/java/example/MainPanel.java
@@ -388,8 +388,14 @@ class TabDragSourceListener implements DragSourceListener {
   }
 
   @Override public void dragDropEnd(DragSourceDropEvent e) {
+    // System.out.println("dragDropEnd");
     // dragTabIndex = -1;
     // glassPane.setVisible(false);
+    Component c = e.getDragSourceContext().getComponent();
+    if (c instanceof JComponent) {
+      JRootPane rp = ((JComponent) c).getRootPane();
+      Optional.ofNullable(rp.getGlassPane()).ifPresent(gp -> gp.setVisible(false));
+    }
   }
 
   @Override public void dropActionChanged(DragSourceDragEvent e) {


### PR DESCRIPTION
Even if you cancel the dragging of tabs by pressing ESC or right-clicking the mouse, the tabs will still be displayed in the tab area if the debug display is enabled.