### PR TITLE
fix: #36 ListCellItemCheckBoxes: rollover effect not applied to first cell in JList

### DIFF
--- a/examples/ListCellItemCheckBoxes/src/java/example/MainPanel.java
+++ b/examples/ListCellItemCheckBoxes/src/java/example/MainPanel.java
@@ -215,7 +215,7 @@ class RubberBandSelectionList<E extends ListItem> extends JList<E> {
         idx = -1;
       }
       Rectangle rect = new Rectangle();
-      if (idx > 0) {
+      if (idx >= 0) {
         rect.add(getCellBounds(idx, idx));
         if (rollOverIndex >= 0 && idx != rollOverIndex) {
           rect.add(getCellBounds(rollOverIndex, rollOverIndex));


### PR DESCRIPTION
In the sample code for ListCellItemCheckBoxes, the `JList#locationToIndex(Point)` method is used to get the cell index closest to the mouse cursor position in the list's coordinate system, but the code does not handle the case where this is 0.